### PR TITLE
Bump metrics-appoptics and DW versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,8 @@
     <url>https://github.com/appoptics/dropwizard-metrics-appoptics</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <metrics.appoptics.version>1.0.2</metrics.appoptics.version>
-        <dropwizard.metrics.version>1.0.3</dropwizard.metrics.version>
+        <metrics.appoptics.version>1.0.3</metrics.appoptics.version>
+        <dropwizard.metrics.version>1.2.9</dropwizard.metrics.version>
     </properties>
     <licenses>
         <license>


### PR DESCRIPTION
This is to handle deprecated Jackson versions that have CVEs.